### PR TITLE
[Fix] 오픈소스라이선스 표기오류 수정

### DIFF
--- a/Req/Settings.bundle/Root.plist
+++ b/Req/Settings.bundle/Root.plist
@@ -10,7 +10,7 @@
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 			<key>Title</key>
-			<string>오픈 라이선스</string>
+			<string>오픈소스 라이선스</string>
 			<key>File</key>
 			<string>LottieLicense</string>
 		</dict>


### PR DESCRIPTION
오픈라이선스 -> 오픈소스 라이선스로 표기 오류 수정